### PR TITLE
add User with JPA without batch

### DIFF
--- a/src/main/java/com/cheeper/buildbulk/TessteUserJpa.java
+++ b/src/main/java/com/cheeper/buildbulk/TessteUserJpa.java
@@ -1,0 +1,36 @@
+package com.cheeper.buildbulk;
+
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.EntityTransaction;
+import javax.persistence.PersistenceUnit;
+
+@Component
+public class TessteUserJpa implements CommandLineRunner {
+
+    @PersistenceUnit
+    private EntityManagerFactory emf;
+
+    @Override
+    public void run(String... args) throws Exception {
+        long inicio = System.currentTimeMillis();
+
+        EntityManager em = emf.createEntityManager();
+        EntityTransaction tx = em.getTransaction();
+
+        tx.begin();
+
+        for (int i = 0; i < 10000; i++) {
+            em.createNativeQuery(
+                    "insert into user (name, email,profile_name,password, bio, verified_email) " +
+                            "values ('Mario', 'mario@cheeper.com', 'mario" + i + "', '123', 'CTO', true);").executeUpdate();
+        }
+        tx.commit();
+
+        long fim = System.currentTimeMillis();
+        System.out.println(" ******** TEMPO: " + (fim - inicio) / 1000);
+    }
+}

--- a/src/main/java/com/cheeper/buildbulk/web/BuilBulkController.java
+++ b/src/main/java/com/cheeper/buildbulk/web/BuilBulkController.java
@@ -1,4 +1,4 @@
-package com.cheeper.buildbulk;
+package com.cheeper.buildbulk.web;
 
 import com.github.javafaker.Faker;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/main/java/com/cheeper/buildbulk/web/Cheep.java
+++ b/src/main/java/com/cheeper/buildbulk/web/Cheep.java
@@ -1,4 +1,4 @@
-package com.cheeper.buildbulk;
+package com.cheeper.buildbulk.web;
 
 import org.springframework.data.domain.Persistable;
 

--- a/src/main/java/com/cheeper/buildbulk/web/CheepRepository.java
+++ b/src/main/java/com/cheeper/buildbulk/web/CheepRepository.java
@@ -1,7 +1,5 @@
-package com.cheeper.buildbulk;
+package com.cheeper.buildbulk.web;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-
-import java.util.List;
 
 public interface CheepRepository extends JpaRepository<Cheep, Long> { }

--- a/src/main/java/com/cheeper/buildbulk/web/User.java
+++ b/src/main/java/com/cheeper/buildbulk/web/User.java
@@ -1,4 +1,4 @@
-package com.cheeper.buildbulk;
+package com.cheeper.buildbulk.web;
 
 import org.springframework.data.domain.Persistable;
 
@@ -12,7 +12,7 @@ import java.util.Set;
 @Entity
 public class User implements Persistable {
 
-    @Id
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer id;
     private String email;
     private String password;

--- a/src/main/java/com/cheeper/buildbulk/web/UserRepository.java
+++ b/src/main/java/com/cheeper/buildbulk/web/UserRepository.java
@@ -1,7 +1,5 @@
-package com.cheeper.buildbulk;
+package com.cheeper.buildbulk.web;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-
-import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Integer> { }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,13 +3,13 @@ server:
 spring:
   jpa:
     properties:
-      hibernate.jdbc.batch_size: 30
-      hibernate.generate_statistics: true
-    show-sql: true
+#      hibernate.jdbc.batch_size: 30
+      hibernate.generate_statistics: false
+    show-sql: false
     hibernate:
       ddl-auto: validate
   datasource:
     driverClassName: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://localhost:3306/cheeper?cachePrepStmts=true&reWriteBatchedInserts=true
+    url: jdbc:mysql://localhost:3306/cheeper #?cachePrepStmts=true&reWriteBatchedInserts=true
     username: root
     password: cheeper


### PR DESCRIPTION
Aqui usei apenas JPA com native query na mão mesmo e gravou 10k registros de 25 a 27 segundos desligando show_sql e estatísticas... Não to usando o batch(não funcionou dessa forma que eu fiz na verdade, vou fazer outro exemplo) mas está bem melhor que os 2 minutos de ontem